### PR TITLE
Outdated git repo link for ui customization

### DIFF
--- a/aspnet/tutorials/web-api-help-pages-using-swagger.rst
+++ b/aspnet/tutorials/web-api-help-pages-using-swagger.rst
@@ -337,7 +337,7 @@ Enable static files middleware.
         
     }
 
-Acquire the core *index.html* file used for the Swagger UI page from the `Github repository <https://github.com/swagger-api/swagger-ui/blob/master/src/main/html/index.html>`_ and put that in the ``wwwroot/swagger/ui`` folder and also create a new ``custom.css`` file in the same folder.
+Acquire the core *index.html* file used for the Swagger UI page from the `Github repository <https://github.com/domaindrivendev/Ahoy/tree/master/test/WebSites/CustomizedUi/wwwroot/swagger/ui>`_ and put that in the ``wwwroot/swagger/ui`` folder and also create a new ``custom.css`` file in the same folder.
 
 .. image:: web-api-help-pages-using-swagger/_static/custom-files-folder-view.png
     :scale: 80%


### PR DESCRIPTION
The link for index.html to customize UI is not working. The current swagger ui for .net core should be 
https://github.com/domaindrivendev/Ahoy/tree/master/test/WebSites/CustomizedUi/wwwroot/swagger/ui
